### PR TITLE
Fixing issues with container starting and staying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ RUN apt update -y && apt install -y gnupg wget openjdk-11-jre && \
     apt update && \
     apt install jenkins -y && \
     service jenkins start && \
-    cat /var/lib/jenkins/secrets/initialAdminPassword
+    touch start.sh && \
+    chmod +x start.sh
 
-# CMD tail -f /dev/null 
+RUN echo '\
+#!/bin/bash\n\
+service jenkins start\n\
+tail -F anything\n\
+' > start.sh
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ services:
   jenkins:
     container_name: jenk
     image: homejenkins
-    tty: true
+    command: bash start.sh
     ports: 
       - "8080:8080"
     volumes:
-      - "$PWD/jenkins_home:/var/jenkins_home"
+      - "./jenkins_home:/var/jenkins_home"
     networks:
       - net
 


### PR DESCRIPTION
Previously the container would shutdown because the service command
finishes with exit code 0.
Now creating a script in the container to start the jenkins service
and then running a command that intentionally hangs.
So far, this is the workaround I've foudn.